### PR TITLE
Update the authentication TCK runner to support running against an existing installaton.

### DIFF
--- a/authentication/wildfly/configure-server.cli
+++ b/authentication/wildfly/configure-server.cli
@@ -1,5 +1,13 @@
 embed-server --admin-only=true
-/subsystem=logging/logger=org.wildfly.security:add(level=TRACE)
+
+if (outcome != success) of /subsystem=logging/logger=org.wildfly.security:read-resource
+    /subsystem=logging/logger=org.wildfly.security:add(level=TRACE)
+end-if
+
 /subsystem=undertow/application-security-domain=other:write-attribute(name=integrated-jaspi, value=false)
-/subsystem=elytron/policy=jacc:add(jacc-policy={})
+
+if (outcome != success) of /subsystem=elytron/policy=jacc:read-resource
+    /subsystem=elytron/policy=jacc:add(jacc-policy={})
+end-if
+
 stop-embedded-server

--- a/authentication/wildfly/pom.xml
+++ b/authentication/wildfly/pom.xml
@@ -47,7 +47,8 @@
         
         <wildfly.home>${project.build.directory}/wildfly</wildfly.home>
         <debugJvmArgs/>
-        <wildfly.skip>false</wildfly.skip>
+        <provision.skip>false</provision.skip>
+        <configure.skip>false</configure.skip>
     </properties>
 
     <build>
@@ -58,7 +59,7 @@
                 <artifactId>galleon-maven-plugin</artifactId>
                 <version>${version.org.jboss.galleon}</version>
                 <configuration>
-                    <skip>${wildfly.skip}</skip>
+                    <skip>${provision.skip}</skip>
                     <install-dir>${wildfly.home}</install-dir>
                     <record-state>false</record-state>
                     <log-time>${galleon.log.time}</log-time>
@@ -109,7 +110,7 @@
                 <artifactId>wildfly-maven-plugin</artifactId>
                 <version>${version.org.wildfly.wildfly-maven-plugin}</version>
                 <configuration>
-                    <skip>${wildfly.skip}</skip>
+                    <skip>${configure.skip}</skip>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
@scottmarlow / @jamezp This PR adds the ability for the authentication TCK (new tests) to run against an existing WildFly installation.

If the script detects that JBOSS_HOME is set the server at that location will be used, otherwise the script will install Alpha2 using Galleon and test against that instead.
