### PR TITLE
Use the last successful nightly build instead of just the last build …

### DIFF
--- a/.github/workflows/concurrency-tck.yml
+++ b/.github/workflows/concurrency-tck.yml
@@ -43,7 +43,7 @@ jobs:
           cache: 'maven'
       - name: Download the WildFly Nightly and setup the JBOSS_HOME
         run: |
-          wget https://ci.wildfly.org/guestAuth/repository/download/WF_Nightly/latest.lastFinished/wildfly-latest-SNAPSHOT.zip
+          wget https://ci.wildfly.org/guestAuth/repository/download/WF_Nightly/latest.lastSuccessful/wildfly-latest-SNAPSHOT.zip
           unzip wildfly-latest-SNAPSHOT.zip
           rm -rfv wildfly*-src.zip wildfly-latest-SNAPSHOT.zip
           unzip wildfly-*.zip


### PR DESCRIPTION
…in case of a failure.

Signed-off-by: James R. Perkins <jperkins@redhat.com>