### PR TITLE
switch to https://download.eclipse.org/ee4j/glassfish/glassfish-7.0.0.zip

### DIFF
--- a/authentication/clean-tck.sh
+++ b/authentication/clean-tck.sh
@@ -5,7 +5,7 @@ TCK_HOME=authentication-tck-3.0.1
 OLD_TCK_HOME=authentication-tck
 ANT_ZIP=apache-ant-1.9.16-bin.zip
 ANT_HOME=apache-ant-1.9.16
-GLASSFISH_ZIP=glassfish-7.0.0-SNAPSHOT-nightly.zip
+GLASSFISH_ZIP=glassfish-7.0.0.zip
 GLASSFISH_HOME=glassfish7
 
 rm $GLASSFISH_ZIP

--- a/authentication/run-tck.sh
+++ b/authentication/run-tck.sh
@@ -173,8 +173,8 @@ then
     export JAVAEE_HOME=$ENV_ROOT/$OLD_WILDFLY
     export JBOSS_HOME=$JAVAEE_HOME
 
-    GLASSFISH_URL=https://download.eclipse.org/ee4j/glassfish/glassfish-7.0.0-SNAPSHOT-nightly.zip
-    GLASSFISH_ZIP=glassfish-7.0.0-SNAPSHOT-nightly.zip
+    GLASSFISH_URL=https://download.eclipse.org/ee4j/glassfish/glassfish-7.0.0.zip
+    GLASSFISH_ZIP=glassfish-7.0.0.zip
     GLASSFISH_HOME=glassfish7
     export JAVAEE_HOME_RI=$ENV_ROOT/$GLASSFISH_HOME/glassfish
 

--- a/faces/bin/run-tck.sh
+++ b/faces/bin/run-tck.sh
@@ -250,8 +250,8 @@ then
     export JAVAEE_HOME=$OLD_WILDFLY
     export JBOSS_HOME=$JAVAEE_HOME
 
-    GLASSFISH_URL=https://download.eclipse.org/ee4j/glassfish/glassfish-7.0.0-SNAPSHOT-nightly.zip
-    GLASSFISH_ZIP=glassfish-7.0.0-SNAPSHOT-nightly.zip
+    GLASSFISH_URL=https://download.eclipse.org/ee4j/glassfish/glassfish-7.0.0.zip
+    GLASSFISH_ZIP=glassfish-7.0.0.zip
     GLASSFISH_HOME=glassfish7
     export JAVAEE_HOME_RI=$ENV_ROOT/$GLASSFISH_HOME/glassfish
     export DERBY_HOME=$ENV_ROOT/$GLASSFISH_HOME/javadb

--- a/security/clean-tck.sh
+++ b/security/clean-tck.sh
@@ -5,7 +5,7 @@ TCK_HOME=security-tck-3.0.0
 OLD_TCK_HOME=security-tck
 ANT_ZIP=apache-ant-1.9.16-bin.zip
 ANT_HOME=apache-ant-1.9.16
-GLASSFISH_ZIP=glassfish-7.0.0-SNAPSHOT-nightly.zip
+GLASSFISH_ZIP=glassfish-7.0.0.zip
 GLASSFISH_HOME=glassfish7
 
 rm $GLASSFISH_ZIP

--- a/security/run-tck.sh
+++ b/security/run-tck.sh
@@ -173,8 +173,8 @@ then
     export JAVAEE_HOME=$ENV_ROOT/$OLD_WILDFLY
     export JBOSS_HOME=$JAVAEE_HOME
 
-    GLASSFISH_URL=https://download.eclipse.org/ee4j/glassfish/glassfish-7.0.0-SNAPSHOT-nightly.zip
-    GLASSFISH_ZIP=glassfish-7.0.0-SNAPSHOT-nightly.zip
+    GLASSFISH_URL=https://download.eclipse.org/ee4j/glassfish/glassfish-7.0.0.zip
+    GLASSFISH_ZIP=glassfish-7.0.0.zip
     GLASSFISH_HOME=glassfish7
     export JAVAEE_HOME_RI=$ENV_ROOT/$GLASSFISH_HOME/glassfish
     export DERBY_HOME=$ENV_ROOT/$GLASSFISH_HOME/javadb


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

This should help resolve:
```
unzip:  cannot find or open glassfish-7.0.0-SNAPSHOT-nightly.zip, glassfish-7.0.0-SNAPSHOT-nightly.zip.zip or glassfish-7.0.0-SNAPSHOT-nightly.zip.ZIP.
Build step 'Execute shell' marked build as failure
```

This change is needed since the GF 7.0.0 snapshot build is no longer available.