### PR TITLE
[101] Upgrade the Jakarta EE Core TCK runner to use the latest 4.0.12…

### DIFF
--- a/.github/workflows/run-coreprofile-tck.yml
+++ b/.github/workflows/run-coreprofile-tck.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        java: ['11', '17']
+        java: ['11', '17', '21']
 
     # Runner steps
     steps:

--- a/wf-core-tck-runner/pom.xml
+++ b/wf-core-tck-runner/pom.xml
@@ -91,9 +91,9 @@
         <jsonp.tck.version>2.1.1</jsonp.tck.version>
         <jsonb.api.version>3.0.0</jsonb.api.version>
         <rest.api.version>3.1.0</rest.api.version>
-        <core.profile.tck.version>10.0.1</core.profile.tck.version>
-        <cdi.tck.version>4.0.11</cdi.tck.version>
-        <cdi.tck.dist.version>4.0.11</cdi.tck.dist.version>
+        <core.profile.tck.version>10.0.3</core.profile.tck.version>
+        <cdi.tck.version>4.0.12</cdi.tck.version>
+        <cdi.tck.dist.version>${cdi.tck.version}</cdi.tck.dist.version>
         <rest.tck.version>3.1.4</rest.tck.version>
 
         <!-- Test tools/dependencies -->


### PR DESCRIPTION
… CDI TCK. This has fixes for running against Java 21.

Also enable Java 21 on CI.

resolves #101 