### PR TITLE
Several clean up updates to prepare for new branching rules

### DIFF
--- a/.github/workflows/authentication-tck.yml
+++ b/.github/workflows/authentication-tck.yml
@@ -6,12 +6,12 @@ name: Run Jakarta Authentication TCK
 on:
   push:
     branches:
-      - '**'
+      - 'main'
     paths:
       - 'authentication/**'
   pull_request:
     branches:
-      - '**'
+      - 'main'
     paths:
       - 'authentication/**'
     types:
@@ -23,6 +23,11 @@ on:
     - cron: '0 0 * * *' # Every day at 00:00 UTC
   workflow_dispatch:
 
+# Only run the latest job
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 
 jobs:
   build-authentication:
@@ -33,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        java: ['11', '17']
+        java: ['11', '17', '21']
 
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +71,7 @@ jobs:
         if: failure()
         with:
           name: surefire-reports-${{ matrix.os }}-${{ matrix.java }}
-          path: '**/surefire-reports/*.txt'
+          path: '**/surefire-reports/'
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/concurrency-tck.yml
+++ b/.github/workflows/concurrency-tck.yml
@@ -6,12 +6,12 @@ name: Run Jakarta Concurrency TCK
 on:
   push:
     branches:
-      - '**'
+      - 'main'
     paths:
       - 'concurrency/**'
   pull_request:
     branches:
-      - '**'
+      - 'main'
     paths:
       - 'concurrency/**'
     types:
@@ -22,6 +22,11 @@ on:
   schedule:
     - cron: '0 0 * * *' # Every day at 00:00 UTC
   workflow_dispatch:
+
+# Only run the latest job
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
 
 
 jobs:

--- a/.github/workflows/core-profile-tck.yml
+++ b/.github/workflows/core-profile-tck.yml
@@ -6,11 +6,13 @@ name: Jakarta EE Core Profile with WildFly
 # or API.
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
+    branches:
+      - 'main'
+    paths:
+      - 'core-profile/**'
   pull_request:
     branches:
-      - '**'
+      - 'main'
     paths:
       - 'core-profile/**'
   schedule:

--- a/.github/workflows/jakarta-xml-binding-tck.yml
+++ b/.github/workflows/jakarta-xml-binding-tck.yml
@@ -7,10 +7,12 @@ name: Jakarta XML Binding TCK with WildFly
 on:
   #push:
   #  branches-ignore:
-  #    - 'dependabot/**'
+  #    - 'main'
+  #  paths:
+  #    - 'jakarta-xml-binding/**'
   #pull_request:
   #  branches:
-  #    - '**'
+  #    - 'main'
   #  paths:
   #    - 'jakarta-xml-binding/**'
   #schedule:

--- a/.github/workflows/security-tck.yml
+++ b/.github/workflows/security-tck.yml
@@ -23,6 +23,11 @@ on:
     - cron: '0 0 * * *' # Every day at 00:00 UTC
   workflow_dispatch:
 
+# Only run the latest job
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 
 jobs:
   build-security:

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,31 @@
+= wildfly-tck-runners
+
+Test runners for executing various TCKs against a WildFly. Each project should have its own README on how to run the
+specific TCK.
+
+== Branches
+
+This project uses branches to target running on specific versions of https://github.com/wildfly/wildfly[WildFly]. For
+example the 31.x branch will be used to run against the 31.x branch of WildFly. 
+
+=== Updating for branching
+
+Once the WildFly branch is created, a new branch should be created before any new PR's are merged. The branch name
+must match the branch name WildFly used.
+
+==== Creating the branch
+
+* Create a new branch with the same name of the WildFly branch:
+[source,bash]
+----
+git checkout -b ${WILDFLY_BRANCH_NAME}
+----
+
+* Update each POM to the use the latest version of WildFly.
+* Update the CI workflows which create a SNAPSHOT version of WildFly to use for provisioning to the new branch.
+  ** The CI workflows will have an entry like `wildfly/wildfly/.github/workflows/shared-wildfly-build.yml@main`. The
+     `@main` needs to be changed to the `@$\{WILDFLY_BRANCH_NAME}`. The `wildfly-branch` parameter will also need to be
+     updated.
+* Update the branch in each workflow to explicitly define the new branch.
+* Push the branch upstream and change any other CI jobs needed to use this new branch.
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# wildfly-tck-runners
-Test runners for executing various TCKs against a WildFly runtime

--- a/authentication/wildfly-mods/profile.xml
+++ b/authentication/wildfly-mods/profile.xml
@@ -8,7 +8,7 @@
                 <version.jakarta.servlet>6.0.0</version.jakarta.servlet>
                 <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
                 <version.org.jboss.remoting-jmx>3.0.4.Final</version.org.jboss.remoting-jmx>
-                <version.org.wildfly>30.0.0.Final</version.org.wildfly>
+                <version.org.wildfly>31.0.0.Final</version.org.wildfly>
                 <version.org.wildfly.arquillian>5.0.0.Alpha5</version.org.wildfly.arquillian>
                 <version.org.wildfly.core>19.0.1.Final</version.org.wildfly.core>
                 <version.org.wildfly.plugins>2.0.2.Final</version.org.wildfly.plugins>

--- a/authentication/wildfly/pom.xml
+++ b/authentication/wildfly/pom.xml
@@ -36,7 +36,7 @@
         <version.org.jboss.galleon>5.0.5.Final</version.org.jboss.galleon>
         <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
         <version.org.jboss.remoting-jmx>3.0.4.Final</version.org.jboss.remoting-jmx>
-        <version.org.wildfly>30.0.0.Final</version.org.wildfly>
+        <version.org.wildfly>31.0.0.Final</version.org.wildfly>
         <version.org.wildfly.wildfly-maven-plugin>3.0.2.Final</version.org.wildfly.wildfly-maven-plugin>
         <version.org.wildfly.plugins>2.0.2.Final</version.org.wildfly.plugins>
 

--- a/authentication/wildfly/pom.xml
+++ b/authentication/wildfly/pom.xml
@@ -33,81 +33,32 @@
 
     <properties>
         <!--  Versions -->
-        <version.org.jboss.galleon>5.0.5.Final</version.org.jboss.galleon>
-        <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
-        <version.org.jboss.remoting-jmx>3.0.4.Final</version.org.jboss.remoting-jmx>
         <version.org.wildfly>31.0.0.Final</version.org.wildfly>
-        <version.org.wildfly.wildfly-maven-plugin>3.0.2.Final</version.org.wildfly.wildfly-maven-plugin>
-        <version.org.wildfly.plugins>2.0.2.Final</version.org.wildfly.plugins>
+        <wildfly.plugin.version>4.2.2.Final</wildfly.plugin.version>
 
         <!-- Build Properties -->
+        <wildfly.home>${project.build.directory}/wildfly</wildfly.home>
+        <jboss.home>${wildfly.home}</jboss.home>
+        <debugJvmArgs/>
+        <configure.skip>false</configure.skip>
+
+        <!-- Provisioning properties -->
+        <feature.pack.groupId>org.wildfly</feature.pack.groupId>
+        <feature.pack.artifactId>wildfly-ee-galleon-pack</feature.pack.artifactId>
+        <feature.pack.version>${version.org.wildfly}</feature.pack.version>
+
         <galleon.fork.embedded>true</galleon.fork.embedded>
         <galleon.log.time>true</galleon.log.time>
         <galleon.offline>false</galleon.offline>
-        
-        <wildfly.home>${project.build.directory}/wildfly</wildfly.home>
-        <debugJvmArgs/>
-        <provision.skip>false</provision.skip>
-        <configure.skip>false</configure.skip>
     </properties>
 
     <build>
         <plugins>
-            <!-- Use Galleon to provision new server. -->
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
-                <version>${version.org.jboss.galleon}</version>
-                <configuration>
-                    <skip>${provision.skip}</skip>
-                    <install-dir>${wildfly.home}</install-dir>
-                    <record-state>false</record-state>
-                    <log-time>${galleon.log.time}</log-time>
-                    <offline>${galleon.offline}</offline>
-                    <plugin-options>
-                        <!--<jboss-maven-dist/> -->
-                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                    </plugin-options>
-                    <feature-packs>
-                        <feature-pack>
-                            <groupId>org.wildfly</groupId>
-                            <artifactId>wildfly-ee-galleon-pack</artifactId>
-                            <version>${version.org.wildfly}</version>
-                            <inherit-configs>false</inherit-configs>
-                            <included-configs>
-                                <config>
-                                    <model>standalone</model>
-                                    <name>standalone-full.xml</name>
-                                </config>
-                                <config>
-                                    <model>standalone</model>
-                                    <name>standalone.xml</name>
-                                </config>
-                            </included-configs>
-                            <excluded-packages>
-                                <name>product.conf</name>
-                                <name>docs.schema</name>
-                                <name>appclient</name>
-                                <name>domain</name>
-                            </excluded-packages>
-                        </feature-pack>
-                    </feature-packs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>server-provisioning</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>provision</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- Configure the newly provisioned server. -->
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <version>${version.org.wildfly.wildfly-maven-plugin}</version>
+                <version>${wildfly.plugin.version}</version>
                 <configuration>
                     <skip>${configure.skip}</skip>
                 </configuration>
@@ -119,7 +70,7 @@
                             <goal>execute-commands</goal>
                         </goals>
                         <configuration>
-                            <jboss-home>${wildfly.home}</jboss-home>
+                            <jboss-home>${jboss.home}</jboss-home>
                             <offline>true</offline>
                             <scripts>
                                 <script>${project.basedir}/configure-server.cli</script>
@@ -133,6 +84,51 @@
 
     <dependencies>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>provision</id>
+            <activation>
+                <property>
+                    <name>provision.skip</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>provision-server</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <configuration>
+                                    <provisioning-dir>${jboss.home}</provisioning-dir>
+                                    <galleon-options>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    </galleon-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${feature.pack.groupId}</groupId>
+                                            <artifactId>${feature.pack.artifactId}</artifactId>
+                                            <version>${feature.pack.version}</version>
+                                        </feature-pack>
+                                    </feature-packs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <repositories>
         <!-- Required for provisioning WildFly. Not all dependencies currently exist on Maven Central. This is also

--- a/authentication/wildfly/pom.xml
+++ b/authentication/wildfly/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <!--  Versions -->
         <version.org.wildfly>31.0.0.Final</version.org.wildfly>
-        <wildfly.plugin.version>4.2.2.Final</wildfly.plugin.version>
+        <wildfly.plugin.version>5.0.0.Beta3</wildfly.plugin.version>
 
         <!-- Build Properties -->
         <wildfly.home>${project.build.directory}/wildfly</wildfly.home>

--- a/concurrency/concurrency-tck-runner/pom.xml
+++ b/concurrency/concurrency-tck-runner/pom.xml
@@ -52,7 +52,7 @@
         <targetDirectory>${project.basedir}/target</targetDirectory>
 
         <!-- Properties specific for this server tck runner -->
-        <version.org.wildfly>30.0.0.Final</version.org.wildfly>
+        <version.org.wildfly>31.0.0.Final</version.org.wildfly>
         <version.org.wildfly.arquillian>5.0.0.Alpha5</version.org.wildfly.arquillian>
         <!-- Plugin versions -->
         <version.org.jboss.galleon>5.0.5.Final</version.org.jboss.galleon>

--- a/concurrency/concurrency-tck-runner/pom.xml
+++ b/concurrency/concurrency-tck-runner/pom.xml
@@ -55,7 +55,7 @@
         <version.org.wildfly>31.0.0.Final</version.org.wildfly>
         <version.org.wildfly.arquillian>5.0.0.Alpha5</version.org.wildfly.arquillian>
         <!-- Plugin versions -->
-        <wildfly.plugin.version>4.2.2.Final</wildfly.plugin.version>
+        <wildfly.plugin.version>5.0.0.Beta3</wildfly.plugin.version>
 
         <!-- Server Provisioning Settings -->
         <jboss.server.name>wildfly</jboss.server.name>

--- a/concurrency/concurrency-tck-runner/pom.xml
+++ b/concurrency/concurrency-tck-runner/pom.xml
@@ -55,19 +55,23 @@
         <version.org.wildfly>31.0.0.Final</version.org.wildfly>
         <version.org.wildfly.arquillian>5.0.0.Alpha5</version.org.wildfly.arquillian>
         <!-- Plugin versions -->
-        <version.org.jboss.galleon>5.0.5.Final</version.org.jboss.galleon>
-        <version.org.wildfly.plugin>3.0.2.Final</version.org.wildfly.plugin>
-        <!-- Galleon -->
-        <galleon.fork.embedded>true</galleon.fork.embedded>
-        <galleon.log.time>true</galleon.log.time>
-        <galleon.offline>false</galleon.offline>
-        <galleon.skip>false</galleon.skip>
+        <wildfly.plugin.version>4.2.2.Final</wildfly.plugin.version>
+
         <!-- Server Provisioning Settings -->
         <jboss.server.name>wildfly</jboss.server.name>
         <jboss.home>${project.build.directory}/${jboss.server.name}</jboss.home>
         <jboss.modules.dir>${jboss.home}/modules</jboss.modules.dir>
         <jboss.derby.module.dir>${jboss.modules.dir}/org/apache/derby/embedded/main</jboss.derby.module.dir>
         <jboss.tck.module.dir>${jboss.modules.dir}/org/wildfly/concurrent/tck/main</jboss.tck.module.dir>
+
+        <feature.pack.groupId>org.wildfly</feature.pack.groupId>
+        <feature.pack.artifactId>wildfly-ee-galleon-pack</feature.pack.artifactId>
+        <feature.pack.version>${version.org.wildfly}</feature.pack.version>
+
+        <galleon.fork.embedded>true</galleon.fork.embedded>
+        <galleon.log.time>true</galleon.log.time>
+        <galleon.offline>false</galleon.offline>
+        <galleon.skip>false</galleon.skip>
         <!-- TCK Settings -->
         <tck.log.debug>true</tck.log.debug>
         <tck.classifier>local</tck.classifier>
@@ -159,64 +163,32 @@
         <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>
         <plugins>
-            <!-- test server setup -->
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
-                <version>${version.org.jboss.galleon}</version>
-                <configuration>
-                    <skip>${galleon.skip}</skip>
-                    <install-dir>${jboss.home}</install-dir>
-                    <record-state>false</record-state>
-                    <log-time>${galleon.log.time}</log-time>
-                    <offline>${galleon.offline}</offline>
-                    <plugin-options>
-                        <!--<jboss-maven-dist/> -->
-                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                    </plugin-options>
-                    <feature-packs>
-                        <feature-pack>
-                            <groupId>org.wildfly</groupId>
-                            <artifactId>wildfly-galleon-pack</artifactId>
-                            <version>${version.org.wildfly}</version>
-                            <inherit-configs>false</inherit-configs>
-                            <included-configs>
-                                <config>
-                                    <model>standalone</model>
-                                    <name>standalone-full.xml</name>
-                                </config>
-                                <config>
-                                    <model>standalone</model>
-                                    <name>standalone.xml</name>
-                                </config>
-                            </included-configs>
-                            <excluded-packages>
-                                <name>product.conf</name>
-                                <name>docs.schema</name>
-                                <name>appclient</name>
-                                <name>domain</name>
-                            </excluded-packages>
-                        </feature-pack>
-                    </feature-packs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>server-provisioning</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>provision</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <version>${version.org.wildfly.plugin}</version>
-                <configuration>
-                    <skip>${wildfly.skip}</skip>
-                </configuration>
+                <version>${wildfly.plugin.version}</version>
                 <executions>
+                    <execution>
+                        <id>provision-server</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>provision</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${galleon.skip}</skip>
+                            <provisioning-dir>${jboss.home}</provisioning-dir>
+                            <galleon-options>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                            </galleon-options>
+                            <feature-packs>
+                                <feature-pack>
+                                    <groupId>${feature.pack.groupId}</groupId>
+                                    <artifactId>${feature.pack.artifactId}</artifactId>
+                                    <version>${feature.pack.version}</version>
+                                </feature-pack>
+                            </feature-packs>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>configure-server</id>
                         <phase>compile</phase>
@@ -224,6 +196,7 @@
                             <goal>execute-commands</goal>
                         </goals>
                         <configuration>
+                            <skip>${wildfly.skip}</skip>
                             <jboss-home>${jboss.home}</jboss-home>
                             <offline>true</offline>
                             <scripts>

--- a/core-profile/pom.xml
+++ b/core-profile/pom.xml
@@ -107,7 +107,7 @@
         <version.org.wildfly.arquillian>5.0.1.Final</version.org.wildfly.arquillian>
         <wildfly.plugin.version>4.2.2.Final</wildfly.plugin.version>
 
-        <version.org.wildfly>30.0.0.Final</version.org.wildfly>
+        <version.org.wildfly>31.0.0.Final</version.org.wildfly>
 
         <!--gc.args>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006</gc.args-->
         <failsafe.plugin.jdk17.args/>

--- a/core-profile/pom.xml
+++ b/core-profile/pom.xml
@@ -105,7 +105,7 @@
         <weld.version>5.1.2.Final</weld.version>
         <resteasy.version>6.2.7.Final</resteasy.version>
         <version.org.wildfly.arquillian>5.0.1.Final</version.org.wildfly.arquillian>
-        <wildfly.plugin.version>4.2.2.Final</wildfly.plugin.version>
+        <wildfly.plugin.version>5.0.0.Beta3</wildfly.plugin.version>
 
         <version.org.wildfly>31.0.0.Final</version.org.wildfly>
 

--- a/faces/wildfly/pom.xml
+++ b/faces/wildfly/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <!--  Versions -->
         <version.org.wildfly>31.0.0.Final</version.org.wildfly>
-        <wildfly.plugin.version>4.2.2.Final</wildfly.plugin.version>
+        <wildfly.plugin.version>5.0.0.Beta3</wildfly.plugin.version>
 
         <!-- Build Properties -->
         <wildfly.home>${project.build.directory}/wildfly</wildfly.home>

--- a/faces/wildfly/pom.xml
+++ b/faces/wildfly/pom.xml
@@ -33,71 +33,31 @@
 
     <properties>
         <!--  Versions -->
-        <version.org.jboss.galleon>5.1.0.Final</version.org.jboss.galleon>
         <version.org.wildfly>31.0.0.Final</version.org.wildfly>
-        <version.org.wildfly.wildfly-maven-plugin>4.0.1.Final</version.org.wildfly.wildfly-maven-plugin>
+        <wildfly.plugin.version>4.2.2.Final</wildfly.plugin.version>
 
         <!-- Build Properties -->
+        <wildfly.home>${project.build.directory}/wildfly</wildfly.home>
+        <jboss.home>${wildfly.home}</jboss.home>
+        <debugJvmArgs/>
+        <configure.skip>false</configure.skip>
+
+        <!-- Provisioning properties -->
+        <feature.pack.groupId>org.wildfly</feature.pack.groupId>
+        <feature.pack.artifactId>wildfly-ee-galleon-pack</feature.pack.artifactId>
+        <feature.pack.version>${version.org.wildfly}</feature.pack.version>
+
         <galleon.fork.embedded>true</galleon.fork.embedded>
         <galleon.log.time>true</galleon.log.time>
         <galleon.offline>false</galleon.offline>
-        
-        <wildfly.home>${project.build.directory}/wildfly</wildfly.home>
-        <debugJvmArgs/>
-        <provision.skip>false</provision.skip>
-        <configure.skip>false</configure.skip>
     </properties>
 
     <build>
         <plugins>
-            <!-- Use Galleon to provision new server. -->
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
-                <version>${version.org.jboss.galleon}</version>
-                <configuration>
-                    <skip>${provision.skip}</skip>
-                    <install-dir>${wildfly.home}</install-dir>
-                    <record-state>false</record-state>
-                    <log-time>${galleon.log.time}</log-time>
-                    <offline>${galleon.offline}</offline>
-                    <plugin-options>
-                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                    </plugin-options>
-                    <feature-packs>
-                        <feature-pack>
-                            <groupId>org.wildfly</groupId>
-                            <artifactId>wildfly-ee-galleon-pack</artifactId>
-                            <version>${version.org.wildfly}</version>
-                            <inherit-configs>false</inherit-configs>
-                            <included-configs>
-                                <config>
-                                    <model>standalone</model>
-                                    <name>standalone-full.xml</name>
-                                </config>
-                                <config>
-                                    <model>standalone</model>
-                                    <name>standalone.xml</name>
-                                </config>
-                            </included-configs>
-                            <excluded-packages>
-                                <name>product.conf</name>
-                                <name>docs.schema</name>
-                                <name>appclient</name>
-                                <name>domain</name>
-                            </excluded-packages>
-                        </feature-pack>
-                    </feature-packs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>server-provisioning</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>provision</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${wildfly.plugin.version}</version>
             </plugin>
         </plugins>
     </build>
@@ -106,6 +66,48 @@
     </dependencies>
 
     <profiles>
+        <profile>
+            <id>provision</id>
+            <activation>
+                <property>
+                    <name>provision.skip</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>provision-server</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <configuration>
+                                    <provisioning-dir>${jboss.home}</provisioning-dir>
+                                    <galleon-options>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    </galleon-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${feature.pack.groupId}</groupId>
+                                            <artifactId>${feature.pack.artifactId}</artifactId>
+                                            <version>${feature.pack.version}</version>
+                                        </feature-pack>
+                                    </feature-packs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>configure-server</id>
             <activation>
@@ -119,7 +121,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.wildfly-maven-plugin}</version>
                         <configuration>
                             <skip>${configure.skip}</skip>
                         </configuration>
@@ -131,7 +132,7 @@
                                     <goal>execute-commands</goal>
                                 </goals>
                                 <configuration>
-                                    <jboss-home>${wildfly.home}</jboss-home>
+                                    <jboss-home>${jboss.home}</jboss-home>
                                     <offline>true</offline>
                                     <scripts>
                                         <script>${project.basedir}/configure-server.cli</script>

--- a/faces/wildfly/pom.xml
+++ b/faces/wildfly/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <!--  Versions -->
         <version.org.jboss.galleon>5.1.0.Final</version.org.jboss.galleon>
-        <version.org.wildfly>30.0.0.Final</version.org.wildfly>
+        <version.org.wildfly>31.0.0.Final</version.org.wildfly>
         <version.org.wildfly.wildfly-maven-plugin>4.0.1.Final</version.org.wildfly.wildfly-maven-plugin>
 
         <!-- Build Properties -->

--- a/security/wildfly-mods/profile.xml
+++ b/security/wildfly-mods/profile.xml
@@ -8,7 +8,7 @@
                 <version.jakarta.servlet>6.0.0</version.jakarta.servlet>
                 <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
                 <version.org.jboss.remoting-jmx>3.0.4.Final</version.org.jboss.remoting-jmx>
-                <version.org.wildfly>30.0.0.Final</version.org.wildfly>
+                <version.org.wildfly>31.0.0.Final</version.org.wildfly>
                 <version.org.wildfly.arquillian>5.0.0.Alpha5</version.org.wildfly.arquillian>
                 <version.org.wildfly.core>19.0.1.Final</version.org.wildfly.core>
                 <version.org.wildfly.plugins>2.0.2.Final</version.org.wildfly.plugins>

--- a/security/wildfly/pom.xml
+++ b/security/wildfly/pom.xml
@@ -36,7 +36,7 @@
         <version.org.jboss.galleon>5.0.5.Final</version.org.jboss.galleon>
         <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
         <version.org.jboss.remoting-jmx>3.0.4.Final</version.org.jboss.remoting-jmx>
-        <version.org.wildfly>30.0.0.Final</version.org.wildfly>
+        <version.org.wildfly>31.0.0.Final</version.org.wildfly>
         <version.org.wildfly.wildfly-maven-plugin>3.0.2.Final</version.org.wildfly.wildfly-maven-plugin>
         <version.org.wildfly.plugins>2.0.2.Final</version.org.wildfly.plugins>
 

--- a/security/wildfly/pom.xml
+++ b/security/wildfly/pom.xml
@@ -33,81 +33,32 @@
 
     <properties>
         <!--  Versions -->
-        <version.org.jboss.galleon>5.0.5.Final</version.org.jboss.galleon>
-        <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
-        <version.org.jboss.remoting-jmx>3.0.4.Final</version.org.jboss.remoting-jmx>
         <version.org.wildfly>31.0.0.Final</version.org.wildfly>
-        <version.org.wildfly.wildfly-maven-plugin>3.0.2.Final</version.org.wildfly.wildfly-maven-plugin>
-        <version.org.wildfly.plugins>2.0.2.Final</version.org.wildfly.plugins>
+        <wildfly.plugin.version>4.2.2.Final</wildfly.plugin.version>
 
         <!-- Build Properties -->
+        <wildfly.home>${project.build.directory}/wildfly</wildfly.home>
+        <jboss.home>${wildfly.home}</jboss.home>
+        <debugJvmArgs/>
+        <configure.skip>false</configure.skip>
+
+        <!-- Provisioning properties -->
+        <feature.pack.groupId>org.wildfly</feature.pack.groupId>
+        <feature.pack.artifactId>wildfly-ee-galleon-pack</feature.pack.artifactId>
+        <feature.pack.version>${version.org.wildfly}</feature.pack.version>
+
         <galleon.fork.embedded>true</galleon.fork.embedded>
         <galleon.log.time>true</galleon.log.time>
         <galleon.offline>false</galleon.offline>
-        
-        <wildfly.home>${project.build.directory}/wildfly</wildfly.home>
-        <debugJvmArgs/>
-        <provision.skip>false</provision.skip>
-        <configure.skip>false</configure.skip>
     </properties>
 
     <build>
         <plugins>
-            <!-- Use Galleon to provision new server. -->
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
-                <version>${version.org.jboss.galleon}</version>
-                <configuration>
-                    <skip>${provision.skip}</skip>
-                    <install-dir>${wildfly.home}</install-dir>
-                    <record-state>false</record-state>
-                    <log-time>${galleon.log.time}</log-time>
-                    <offline>${galleon.offline}</offline>
-                    <plugin-options>
-                        <!--<jboss-maven-dist/> -->
-                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                    </plugin-options>
-                    <feature-packs>
-                        <feature-pack>
-                            <groupId>org.wildfly</groupId>
-                            <artifactId>wildfly-ee-galleon-pack</artifactId>
-                            <version>${version.org.wildfly}</version>
-                            <inherit-configs>false</inherit-configs>
-                            <included-configs>
-                                <config>
-                                    <model>standalone</model>
-                                    <name>standalone-full.xml</name>
-                                </config>
-                                <config>
-                                    <model>standalone</model>
-                                    <name>standalone.xml</name>
-                                </config>
-                            </included-configs>
-                            <excluded-packages>
-                                <name>product.conf</name>
-                                <name>docs.schema</name>
-                                <name>appclient</name>
-                                <name>domain</name>
-                            </excluded-packages>
-                        </feature-pack>
-                    </feature-packs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>server-provisioning</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>provision</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- Configure the newly provisioned server. -->
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <version>${version.org.wildfly.wildfly-maven-plugin}</version>
+                <version>${wildfly.plugin.version}</version>
                 <configuration>
                     <skip>${configure.skip}</skip>
                 </configuration>
@@ -133,6 +84,51 @@
 
     <dependencies>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>provision</id>
+            <activation>
+                <property>
+                    <name>provision.skip</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>provision-server</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <configuration>
+                                    <provisioning-dir>${jboss.home}</provisioning-dir>
+                                    <galleon-options>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    </galleon-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${feature.pack.groupId}</groupId>
+                                            <artifactId>${feature.pack.artifactId}</artifactId>
+                                            <version>${feature.pack.version}</version>
+                                        </feature-pack>
+                                    </feature-packs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <repositories>
         <!-- Required for provisioning WildFly. Not all dependencies currently exist on Maven Central. This is also

--- a/security/wildfly/pom.xml
+++ b/security/wildfly/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <!--  Versions -->
         <version.org.wildfly>31.0.0.Final</version.org.wildfly>
-        <wildfly.plugin.version>4.2.2.Final</wildfly.plugin.version>
+        <wildfly.plugin.version>5.0.0.Beta3</wildfly.plugin.version>
 
         <!-- Build Properties -->
         <wildfly.home>${project.build.directory}/wildfly</wildfly.home>


### PR DESCRIPTION
This PR cleans up the workflows slightly to ensure consistency. It also changes provisioning for each TCK runner which uses provisioning to use the `org.wildfly.plugins:wildfly-maven-plugin` for provisioning.

The README was updated with instructions on how we will handle branching. The branches will be used to test patch releases while allowing the main branch to move ahead with any required changes.