### PR TITLE
Default to running the 4.0.2 XML Binding TCK

### DIFF
--- a/jakarta-xml-binding/bin/run-tck.sh
+++ b/jakarta-xml-binding/bin/run-tck.sh
@@ -88,7 +88,7 @@ done
 
 shift $((OPTIND - 1))
 
-TCK_VERSION="4.0.1"
+TCK_VERSION="4.0.2"
 verboseArgs="";
 if [ ${verbose} == true ]; then
     verboseArgs="-v"


### PR DESCRIPTION
One more change for defaulting to using the 4.0.2 XML Binding TCK