### PR TITLE
Allows certification on Java SE 21+ Jakarta XML Binding 4.0.2 TCK

### DIFF
--- a/jakarta-xml-binding/bin/run-tck.sh
+++ b/jakarta-xml-binding/bin/run-tck.sh
@@ -88,7 +88,7 @@ done
 
 shift $((OPTIND - 1))
 
-TCK_VERSION="4.0.1"
+TCK_VERSION="4.0.2"
 verboseArgs="";
 if [ ${verbose} == true ]; then
     verboseArgs="-v"


### PR DESCRIPTION
Addresses [WFLY-18892](https://issues.redhat.com/browse/WFLY-18892) by upgrading to 4.0.2 TCK so that the XML Binding could pass on Java 21