### PR TITLE
Exclude the version of jboss-logging from the jboss-logmanager.

### DIFF
--- a/servlet-tck/tck-runner/pom.xml
+++ b/servlet-tck/tck-runner/pom.xml
@@ -142,6 +142,12 @@
             <artifactId>jboss-logmanager</artifactId>
             <version>${version.org.jboss.logging.jboss-logmanager}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Required as the Servlet TCK attempts to add libraries to the deployments. This implementation is already
              provided by WildFly, but we need to satisfy the TCK here. -->


### PR DESCRIPTION
This gets us back to the known failures. I've missed this before because the TCK typically just failed and I failed to look at why. This is required as WildFly now uses JBoss Logging 3.6.1.Final, but the JBoss Log Manager relies on an older version.