### PR TITLE
Move each TCK version to their respective projects. While in some cas…

### DIFF
--- a/jakarta-ee-tck-runners/annotations-tck/annotations-tck-setup/pom.xml
+++ b/jakarta-ee-tck-runners/annotations-tck/annotations-tck-setup/pom.xml
@@ -33,7 +33,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://download.eclipse.org/jakartaee/annotations/${version.jakarta.annotations.tck.short}/jakarta-annotations-tck-${version.jakarta.annotations.tck}.zip</url>
+                            <url>https://download.eclipse.org/jakartaee/annotations/${version.jakarta.annotations.short}/jakarta-annotations-tck-${version.jakarta.annotations.tck}.zip</url>
                             <outputFileName>jakarta-annotations-tck-${version.jakarta.annotations.tck}.zip</outputFileName>
                             <sha256>9421c6ca66274d32dfb408848f75a42d57f120599fe0d8403c5c5c1141d5ac4d</sha256>
                         </configuration>

--- a/jakarta-ee-tck-runners/annotations-tck/pom.xml
+++ b/jakarta-ee-tck-runners/annotations-tck/pom.xml
@@ -4,8 +4,8 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,6 +19,10 @@
     <artifactId>annotations-tck-parent</artifactId>
     <name>WildFly Jakarta Annotations TCK Parent</name>
     <packaging>pom</packaging>
+
+    <properties>
+        <version.jakarta.annotations.tck>${version.jakarta.annotations.short}.0</version.jakarta.annotations.tck>
+    </properties>
 
     <modules>
         <module>annotations-tck-setup</module>

--- a/jakarta-ee-tck-runners/cdi-langmodel-tck/pom.xml
+++ b/jakarta-ee-tck-runners/cdi-langmodel-tck/pom.xml
@@ -4,7 +4,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -18,6 +18,10 @@
     <artifactId>cdi-langmodel-tck-parent</artifactId>
     <name>WildFly Jakarta Lang Model CDI TCK Parent</name>
     <packaging>pom</packaging>
+
+    <properties>
+        <version.jakarta.cdi.tck>${version.jakarta.cdi.short}.0</version.jakarta.cdi.tck>
+    </properties>
 
     <modules>
         <module>cdi-langmodel-tck-setup</module>

--- a/jakarta-ee-tck-runners/cdi-lite-tck/cdi-lite-tck-runner/pom.xml
+++ b/jakarta-ee-tck-runners/cdi-lite-tck/cdi-lite-tck-runner/pom.xml
@@ -128,14 +128,14 @@
         <dependency>
             <groupId>jakarta.tck.coreprofile</groupId>
             <artifactId>cdi-lite-tck-suite</artifactId>
-            <version>${version.jakarta.platform.core.profile.tck.version}</version>
+            <version>${version.jakarta.platform.core.profile.tck}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.coreprofile</groupId>
             <artifactId>cdi-lite-tck-suite</artifactId>
             <type>xml</type>
-            <version>${version.jakarta.platform.core.profile.tck.version}</version>
+            <version>${version.jakarta.platform.core.profile.tck}</version>
             <scope>test</scope>
         </dependency>
 

--- a/jakarta-ee-tck-runners/cdi-lite-tck/pom.xml
+++ b/jakarta-ee-tck-runners/cdi-lite-tck/pom.xml
@@ -20,6 +20,10 @@
     <description>Runs the CDI Lite TCK and Jakarta EE Core Profile CDI TCK Tests</description>
     <packaging>pom</packaging>
 
+    <properties>
+        <version.jakarta.cdi.tck>${version.jakarta.cdi.short}.0</version.jakarta.cdi.tck>
+    </properties>
+
     <profiles>
         <profile>
             <id>standalone-cdi-lite-tck</id>

--- a/jakarta-ee-tck-runners/concurrency-tck/pom.xml
+++ b/jakarta-ee-tck-runners/concurrency-tck/pom.xml
@@ -18,8 +18,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
@@ -36,6 +36,10 @@
     <name>WildFly: Jakarta Concurrency TCK Parent</name>
     <description>A TCK runner for the Jakarta Concurrency TCK</description>
     <packaging>pom</packaging>
+
+    <properties>
+        <version.jakarta.enterprise.concurrency.tck>${version.jakarta.enterprise.concurrency.short}.1</version.jakarta.enterprise.concurrency.tck>
+    </properties>
 
     <modules>
         <module>concurrency-tck-setup</module>

--- a/jakarta-ee-tck-runners/core-profile-tck-runner/pom.xml
+++ b/jakarta-ee-tck-runners/core-profile-tck-runner/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>jakarta.tck.coreprofile</groupId>
             <artifactId>core-profile-tck-impl</artifactId>
-            <version>${version.jakarta.platform.core.profile.tck.version}</version>
+            <version>${version.jakarta.platform.core.profile.tck}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jakarta-ee-tck-runners/core-profile-tck-setup/pom.xml
+++ b/jakarta-ee-tck-runners/core-profile-tck-setup/pom.xml
@@ -34,8 +34,8 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://download.eclipse.org/jakartaee/coreprofile/${version.jakarta.platform.core.profile.tck.version.short}/jakarta-core-profile-tck-${version.jakarta.platform.core.profile.tck.version}.zip</url>
-                            <outputFileName>jakarta-core-profile-tck-${version.jakarta.platform.core.profile.tck.version}.zip</outputFileName>
+                            <url>https://download.eclipse.org/jakartaee/coreprofile/${version.jakarta.platform.core.profile.tck.short}/jakarta-core-profile-tck-${version.jakarta.platform.core.profile.tck}.zip</url>
+                            <outputFileName>jakarta-core-profile-tck-${version.jakarta.platform.core.profile.tck}.zip</outputFileName>
                             <sha256>0357bfab7025972edb2bf50277b6b4206b499a2961bc94e783f34782cc4a9bda</sha256>
                         </configuration>
                     </execution>
@@ -56,9 +56,9 @@
                         <configuration>
                             <groupId>jakarta.tck.coreprofile</groupId>
                             <artifactId>core-tck-parent</artifactId>
-                            <version>${version.jakarta.platform.core.profile.tck.version}</version>
+                            <version>${version.jakarta.platform.core.profile.tck}</version>
                             <packaging>pom</packaging>
-                            <file>${tck.dir}/core-profile-tck-${version.jakarta.platform.core.profile.tck.version}/artifacts/core-tck-parent-${version.jakarta.platform.core.profile.tck.version}.pom</file>
+                            <file>${tck.dir}/core-profile-tck-${version.jakarta.platform.core.profile.tck}/artifacts/core-tck-parent-${version.jakarta.platform.core.profile.tck}.pom</file>
                             <generatePom>false</generatePom>
                         </configuration>
                     </execution>
@@ -72,9 +72,9 @@
                         <configuration>
                             <groupId>jakarta.tck.coreprofile</groupId>
                             <artifactId>core-tck-jsonp-extension</artifactId>
-                            <version>${version.jakarta.platform.core.profile.tck.version}</version>
+                            <version>${version.jakarta.platform.core.profile.tck}</version>
                             <packaging>jar</packaging>
-                            <file>${tck.dir}/core-profile-tck-${version.jakarta.platform.core.profile.tck.version}/artifacts/core-tck-jsonp-extension-${version.jakarta.platform.core.profile.tck.version}.jar</file>
+                            <file>${tck.dir}/core-profile-tck-${version.jakarta.platform.core.profile.tck}/artifacts/core-tck-jsonp-extension-${version.jakarta.platform.core.profile.tck}.jar</file>
                             <generatePom>true</generatePom>
                         </configuration>
                     </execution>
@@ -88,9 +88,9 @@
                         <configuration>
                             <groupId>jakarta.tck.coreprofile</groupId>
                             <artifactId>core-profile-tck-impl</artifactId>
-                            <version>${version.jakarta.platform.core.profile.tck.version}</version>
+                            <version>${version.jakarta.platform.core.profile.tck}</version>
                             <packaging>jar</packaging>
-                            <file>${tck.dir}/core-profile-tck-${version.jakarta.platform.core.profile.tck.version}/artifacts/core-profile-tck-impl-${version.jakarta.platform.core.profile.tck.version}.jar</file>
+                            <file>${tck.dir}/core-profile-tck-${version.jakarta.platform.core.profile.tck}/artifacts/core-profile-tck-impl-${version.jakarta.platform.core.profile.tck}.jar</file>
                             <generatePom>true</generatePom>
                         </configuration>
                     </execution>
@@ -104,9 +104,9 @@
                         <configuration>
                             <groupId>jakarta.tck.coreprofile</groupId>
                             <artifactId>cdi-lite-tck-suite</artifactId>
-                            <version>${version.jakarta.platform.core.profile.tck.version}</version>
+                            <version>${version.jakarta.platform.core.profile.tck}</version>
                             <packaging>jar</packaging>
-                            <file>${tck.dir}/core-profile-tck-${version.jakarta.platform.core.profile.tck.version}/artifacts/cdi-lite-tck-suite-${version.jakarta.platform.core.profile.tck.version}.jar</file>
+                            <file>${tck.dir}/core-profile-tck-${version.jakarta.platform.core.profile.tck}/artifacts/cdi-lite-tck-suite-${version.jakarta.platform.core.profile.tck}.jar</file>
                             <generatePom>true</generatePom>
                         </configuration>
                     </execution>
@@ -119,9 +119,9 @@
                         <configuration>
                             <groupId>jakarta.tck.coreprofile</groupId>
                             <artifactId>cdi-lite-tck-suite</artifactId>
-                            <version>${version.jakarta.platform.core.profile.tck.version}</version>
+                            <version>${version.jakarta.platform.core.profile.tck}</version>
                             <packaging>xml</packaging>
-                            <file>${tck.dir}/core-profile-tck-${version.jakarta.platform.core.profile.tck.version}/artifacts/cdi-lite-tck-suite-${version.jakarta.platform.core.profile.tck.version}.xml</file>
+                            <file>${tck.dir}/core-profile-tck-${version.jakarta.platform.core.profile.tck}/artifacts/cdi-lite-tck-suite-${version.jakarta.platform.core.profile.tck}.xml</file>
                             <generatePom>false</generatePom>
                         </configuration>
                     </execution>
@@ -134,8 +134,8 @@
                         <configuration>
                             <groupId>jakarta.tck.coreprofile</groupId>
                             <artifactId>rest-tck-suite</artifactId>
-                            <version>${version.jakarta.platform.core.profile.tck.version}</version>
-                            <file>${tck.dir}/core-profile-tck-${version.jakarta.platform.core.profile.tck.version}/artifacts/rest-tck-suite-${version.jakarta.platform.core.profile.tck.version}.jar</file>
+                            <version>${version.jakarta.platform.core.profile.tck}</version>
+                            <file>${tck.dir}/core-profile-tck-${version.jakarta.platform.core.profile.tck}/artifacts/rest-tck-suite-${version.jakarta.platform.core.profile.tck}.jar</file>
                             <generatePom>true</generatePom>
                         </configuration>
                     </execution>

--- a/jakarta-ee-tck-runners/inject-tck/inject-tck-setup/pom.xml
+++ b/jakarta-ee-tck-runners/inject-tck/inject-tck-setup/pom.xml
@@ -33,7 +33,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://download.eclipse.org/jakartaee/dependency-injection/${version.jakarta.inject.tck.short}/jakarta.inject-tck-${version.jakarta.inject.tck}-bin.zip</url>
+                            <url>https://download.eclipse.org/jakartaee/dependency-injection/${version.jakarta.inject.short}/jakarta.inject-tck-${version.jakarta.inject.tck}-bin.zip</url>
                             <outputFileName>jakarta.inject-tck-${version.jakarta.inject.tck}-bin.zip</outputFileName>
                             <sha256>23bce4317ca061c3de648566cdf65c74b57e1264d6891f366567955d6b834972</sha256>
                         </configuration>

--- a/jakarta-ee-tck-runners/inject-tck/pom.xml
+++ b/jakarta-ee-tck-runners/inject-tck/pom.xml
@@ -20,6 +20,10 @@
     <name>WildFly Jakarta Inject TCK Parent</name>
     <packaging>pom</packaging>
 
+    <properties>
+        <version.jakarta.inject.tck>${version.jakarta.inject.short}.2</version.jakarta.inject.tck>
+    </properties>
+
     <modules>
         <module>inject-tck-setup</module>
         <module>inject-tck-runner</module>

--- a/jakarta-ee-tck-runners/jsonb-tck/jsonb-tck-setup/pom.xml
+++ b/jakarta-ee-tck-runners/jsonb-tck/jsonb-tck-setup/pom.xml
@@ -33,7 +33,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://download.eclipse.org/jakartaee/jsonb/${version.jakarta.json.binding.tck.short}/jakarta-jsonb-tck-${version.jakarta.json.binding.tck}.zip</url>
+                            <url>https://download.eclipse.org/jakartaee/jsonb/${version.jakarta.json.binding.short}/jakarta-jsonb-tck-${version.jakarta.json.binding.tck}.zip</url>
                             <outputFileName>jakarta-jsonb-tck-${version.jakarta.json.binding.tck}.zip</outputFileName>
                             <sha256>954fd9a3a67059ddeabe5f51462a6a3b542c94fc798094dd8c312a6a28ef2d0b</sha256>
                         </configuration>

--- a/jakarta-ee-tck-runners/jsonb-tck/pom.xml
+++ b/jakarta-ee-tck-runners/jsonb-tck/pom.xml
@@ -20,6 +20,10 @@
     <name>WildFly Jakarta JSON Binding TCK Parent</name>
     <packaging>pom</packaging>
 
+    <properties>
+        <version.jakarta.json.binding.tck>${version.jakarta.json.binding.short}.0</version.jakarta.json.binding.tck>
+    </properties>
+
     <modules>
         <module>jsonb-tck-setup</module>
         <module>jsonb-tck-runner</module>

--- a/jakarta-ee-tck-runners/jsonp-tck/jsonp-tck-setup/pom.xml
+++ b/jakarta-ee-tck-runners/jsonp-tck/jsonp-tck-setup/pom.xml
@@ -33,7 +33,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://download.eclipse.org/jakartaee/jsonp/${version.jakarta.json.tck.short}/jakarta-jsonp-tck-${version.jakarta.json.tck}.zip</url>
+                            <url>https://download.eclipse.org/jakartaee/jsonp/${version.jakarta.json.short}/jakarta-jsonp-tck-${version.jakarta.json.tck}.zip</url>
                             <outputFileName>jakarta-jsonp-tck-${version.jakarta.json.tck}.zip</outputFileName>
                             <sha256>949f203de84deffa8c7892b555918e42f1dd220ccb7b6800741ea58af62737c1</sha256>
                         </configuration>

--- a/jakarta-ee-tck-runners/pom.xml
+++ b/jakarta-ee-tck-runners/pom.xml
@@ -87,41 +87,34 @@
         <addjdkopens/>
 
         <!-- Jakarta EE API Versions, please keep these in alphabetical order. -->
-        <version.jakarta.annotations.tck.short>3.0</version.jakarta.annotations.tck.short>
-        <version.jakarta.annotations.tck>${version.jakarta.annotations.tck.short}.0</version.jakarta.annotations.tck>
-        <version.jakarta.annotations.api>${version.jakarta.annotations.tck.short}.0</version.jakarta.annotations.api>
+        <version.jakarta.annotations.short>3.0</version.jakarta.annotations.short>
+        <version.jakarta.annotations.api>${version.jakarta.annotations.short}.0</version.jakarta.annotations.api>
 
-        <version.jakarta.inject.tck.short>2.0</version.jakarta.inject.tck.short>
-        <version.jakarta.inject.tck>${version.jakarta.inject.tck.short}.2</version.jakarta.inject.tck>
-        <version.jakarta.inject.api>${version.jakarta.inject.tck.short}.1</version.jakarta.inject.api>
+        <version.jakarta.inject.short>2.0</version.jakarta.inject.short>
+        <version.jakarta.inject.api>${version.jakarta.inject.short}.1</version.jakarta.inject.api>
 
         <version.jakarta.cdi.short>4.1</version.jakarta.cdi.short>
         <version.jakarta.cdi.api>${version.jakarta.cdi.short}.0</version.jakarta.cdi.api>
-        <version.jakarta.cdi.tck>${version.jakarta.cdi.short}.0</version.jakarta.cdi.tck>
 
         <version.jakarta.enterprise.concurrency.short>3.1</version.jakarta.enterprise.concurrency.short>
         <version.jakarta.enterprise.concurrency.api>${version.jakarta.enterprise.concurrency.short}.1</version.jakarta.enterprise.concurrency.api>
-        <version.jakarta.enterprise.concurrency.tck>${version.jakarta.enterprise.concurrency.short}.1</version.jakarta.enterprise.concurrency.tck>
 
         <version.jakarta.ejb.short>4.0</version.jakarta.ejb.short>
         <version.jakarta.ejb.api>${version.jakarta.ejb.short}.0</version.jakarta.ejb.api>
-        <version.jakarta.ejb.tck>${version.jakarta.ejb.short}.0</version.jakarta.ejb.tck>
 
-        <version.jakarta.json.tck.short>2.1</version.jakarta.json.tck.short>
-        <version.jakarta.json.tck>${version.jakarta.json.tck.short}.1</version.jakarta.json.tck>
+        <version.jakarta.json.short>2.1</version.jakarta.json.short>
+        <version.jakarta.json.tck>${version.jakarta.json.short}.1</version.jakarta.json.tck>
 
-        <version.jakarta.json.binding.tck.short>3.0</version.jakarta.json.binding.tck.short>
-        <version.jakarta.json.binding.tck>${version.jakarta.json.binding.tck.short}.0</version.jakarta.json.binding.tck>
+        <version.jakarta.json.binding.short>3.0</version.jakarta.json.binding.short>
+        <version.jakarta.json.binding.api>${version.jakarta.json.binding.short}.0</version.jakarta.json.binding.api>
 
-        <version.jakarta.platform.core.profile.tck.version.short>11.0</version.jakarta.platform.core.profile.tck.version.short>
-        <version.jakarta.platform.core.profile.tck.version>${version.jakarta.platform.core.profile.tck.version.short}.0</version.jakarta.platform.core.profile.tck.version>
+        <version.jakarta.platform.core.profile.tck.short>11.0</version.jakarta.platform.core.profile.tck.short>
+        <version.jakarta.platform.core.profile.tck>${version.jakarta.platform.core.profile.tck.short}.0</version.jakarta.platform.core.profile.tck>
 
-        <version.jakarta.servlet.tck.short>6.1</version.jakarta.servlet.tck.short>
-        <version.jakarta.servlet.tck>${version.jakarta.servlet.tck.short}.1</version.jakarta.servlet.tck>
-        <version.jakarta.servlet.api>${version.jakarta.servlet.tck.short}.0</version.jakarta.servlet.api>
+        <version.jakarta.servlet.short>6.1</version.jakarta.servlet.short>
+        <version.jakarta.servlet.api>${version.jakarta.servlet.short}.0</version.jakarta.servlet.api>
 
-        <version.jakarta.ws.rs.tck.short>4.0</version.jakarta.ws.rs.tck.short>
-        <version.jakarta.ws.rs.tck>${version.jakarta.ws.rs.tck.short}.1</version.jakarta.ws.rs.tck>
+        <version.jakarta.ws.rs.short>4.0</version.jakarta.ws.rs.short>
 
         <!-- Specification implementation versions, please keep these in alphabetical order -->
         <version.org.jboss.resteasy>6.2.11.Final</version.org.jboss.resteasy>

--- a/jakarta-ee-tck-runners/rest-tck/pom.xml
+++ b/jakarta-ee-tck-runners/rest-tck/pom.xml
@@ -4,8 +4,8 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,6 +19,10 @@
     <artifactId>rest-tck-parent</artifactId>
     <name>WildFly Jakarta REST TCK Parent</name>
     <packaging>pom</packaging>
+
+    <properties>
+        <version.jakarta.ws.rs.tck>${version.jakarta.ws.rs.short}.1</version.jakarta.ws.rs.tck>
+    </properties>
 
     <modules>
         <module>rest-tck-setup</module>

--- a/jakarta-ee-tck-runners/rest-tck/rest-tck-runner/pom.xml
+++ b/jakarta-ee-tck-runners/rest-tck/rest-tck-runner/pom.xml
@@ -360,7 +360,7 @@
                 <dependency>
                     <groupId>jakarta.tck.coreprofile</groupId>
                     <artifactId>rest-tck-suite</artifactId>
-                    <version>${version.jakarta.platform.core.profile.tck.version}</version>
+                    <version>${version.jakarta.platform.core.profile.tck}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/jakarta-ee-tck-runners/rest-tck/rest-tck-setup/pom.xml
+++ b/jakarta-ee-tck-runners/rest-tck/rest-tck-setup/pom.xml
@@ -33,7 +33,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://download.eclipse.org/jakartaee/restful-ws/${version.jakarta.ws.rs.tck.short}/jakarta-restful-ws-tck-${version.jakarta.ws.rs.tck}.zip</url>
+                            <url>https://download.eclipse.org/jakartaee/restful-ws/${version.jakarta.ws.rs.short}/jakarta-restful-ws-tck-${version.jakarta.ws.rs.tck}.zip</url>
                             <outputFileName>jakarta-restful-ws-tck-${version.jakarta.ws.rs.tck}.zip</outputFileName>
                             <sha256>b6290c1b5b3d2fdd9cc700a999243492a7e27b94a9b6af1974ff4dc5bfbf98f2</sha256>
                         </configuration>

--- a/jakarta-ee-tck-runners/servlet-tck/pom.xml
+++ b/jakarta-ee-tck-runners/servlet-tck/pom.xml
@@ -22,6 +22,10 @@
     <name>WildFly: Jakarta Servlet TCK Parent</name>
     <description>A TCK runner for the Jakarta Servlet TCK</description>
 
+    <properties>
+        <version.jakarta.servlet.tck>${version.jakarta.servlet.short}.1</version.jakarta.servlet.tck>
+    </properties>
+
     <modules>
         <module>servlet-tck-setup</module>
         <module>servlet-tck-runner</module>

--- a/jakarta-ee-tck-runners/servlet-tck/servlet-tck-setup/pom.xml
+++ b/jakarta-ee-tck-runners/servlet-tck/servlet-tck-setup/pom.xml
@@ -36,7 +36,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://download.eclipse.org/jakartaee/servlet/${version.jakarta.servlet.tck.short}/jakarta-servlet-tck-${version.jakarta.servlet.tck}.zip</url>
+                            <url>https://download.eclipse.org/jakartaee/servlet/${version.jakarta.servlet.short}/jakarta-servlet-tck-${version.jakarta.servlet.tck}.zip</url>
                             <unpack>true</unpack>
                             <outputDirectory>${tck.download.directory}</outputDirectory>
                             <outputFileName>jakarta-servlet-tck-${version.jakarta.servlet.tck}.zip</outputFileName>


### PR DESCRIPTION
…es this might mean defining the version in different POM's, it allows for better test triggering support in CI.