### PR TITLE
Disable ant download from the old security tck pom.xml

### DIFF
--- a/security/run-tck.sh
+++ b/security/run-tck.sh
@@ -226,7 +226,7 @@ then
     then
         echo "Preparing Old TCK."
         pushd $TCK_ROOT/old-tck/build
-        mvn ${MVN_ARGS} install
+        mvn ${MVN_ARGS} install -Ddownload.plugin.skip=true
         popd
         unzip ${UNZIP_ARGS} $TCK_ROOT/old-tck/source/release/SECURITYAPI_BUILD/latest/security-tck.zip
         pushd $JEETCK_MODS


### PR DESCRIPTION
This should prevent the old security TCK from downloading ant.

I think I can't quite test this by just editing the Jenkins job.