### PR TITLE
Disable ant download from the old authentication tck pom.xml

### DIFF
--- a/authentication/run-tck.sh
+++ b/authentication/run-tck.sh
@@ -200,7 +200,7 @@ then
     then
         echo "Preparing Old TCK."
         pushd $TCK_ROOT/old-tck/build
-        mvn ${MVN_ARGS} install
+        mvn ${MVN_ARGS} install -Ddownload.plugin.skip=true
         popd
         unzip ${UNZIP_ARGS} $TCK_ROOT/old-tck/source/release/JASPIC_BUILD/latest/authentication-tck.zip
         echo "Fix the build.xml in the old TCK."


### PR DESCRIPTION
This is a follow up to https://github.com/wildfly/wildfly-tck-runners/pull/248, disabling ant download from another job.

Recent failure that I aim to fix by this is here: https://jenkins-csb-wildfly-tck.dno.corp.redhat.com/job/jakartaee-ee10/job/newauth/4032//consoleText

Cc @jamezp @scottmarlow 