### PR TITLE
Disable ant download from the old authentication, security and faces tcks

### DIFF
--- a/authentication/run-tck.sh
+++ b/authentication/run-tck.sh
@@ -153,12 +153,13 @@ OLD_TCK_HOME=authentication-tck
 if [[ -n $TCK_PORTING_KIT ]] 
 then
     echo "Hold on tight!"
-    
+
+    ANT_VERSION="1.9.16"
+    ANT_URL="https://dlcdn.apache.org//ant/binaries/apache-ant-${ANT_VERSION}-bin.zip"
     if [[ ! "$ANT_HOME" ]];
     then
-        ANT_URL=https://dlcdn.apache.org//ant/binaries/apache-ant-1.9.16-bin.zip
-        ANT_ZIP=apache-ant-1.9.16-bin.zip
-        ANT_HOME=apache-ant-1.9.16
+        ANT_ZIP="apache-ant-${ANT_VERSION}-bin.zip"
+        ANT_HOME="apache-ant-${ANT_VERSION}"
         echo "Installing Ant."
         curl $ANT_URL -o $ANT_ZIP
         unzip ${UNZIP_ARGS} $ANT_ZIP
@@ -200,7 +201,7 @@ then
     then
         echo "Preparing Old TCK."
         pushd $TCK_ROOT/old-tck/build
-        mvn ${MVN_ARGS} install
+        mvn ${MVN_ARGS} install "-Dant.zip.url=${ANT_URL}" "-Dant.version=${ANT_VERSION}"
         popd
         unzip ${UNZIP_ARGS} $TCK_ROOT/old-tck/source/release/JASPIC_BUILD/latest/authentication-tck.zip
         echo "Fix the build.xml in the old TCK."

--- a/faces/bin/run-tck.sh
+++ b/faces/bin/run-tck.sh
@@ -237,12 +237,13 @@ pushd "${WORK_DIR}"
 if [[ -n $TCK_PORTING_KIT ]] 
 then
     echo "Hold on tight!"
-    
-    ANT_URL=https://dlcdn.apache.org//ant/binaries/apache-ant-1.9.16-bin.zip
+
+    ANT_VERSION="1.9.16"
+    ANT_URL="https://dlcdn.apache.org//ant/binaries/apache-ant-${ANT_VERSION}-bin.zip"
     ANT_CONTRIB_URL=https://sourceforge.net/projects/ant-contrib/files/ant-contrib/1.0b3/ant-contrib-1.0b3-bin.zip/download
-    ANT_ZIP=apache-ant-1.9.16-bin.zip
+    ANT_ZIP="apache-ant-${ANT_VERSION}-bin.zip"
     ANT_CONTRIB_ZIP=ant-contrib-1.0b3-bin.zip
-    export ANT_HOME="${WORK_DIR}"/apache-ant-1.9.16
+    export ANT_HOME="${WORK_DIR}/apache-ant-${ANT_VERSION}"
     export PATH=$ANT_HOME/bin:$PATH
     if ! test -d $ANT_HOME
     then
@@ -294,7 +295,7 @@ then
     then
         echo "Preparing Old TCK."
         pushd $TCK_ROOT/old-tck/build
-        mvn ${MVN_ARGS} install -Dtck.mode=platform
+        mvn ${MVN_ARGS} install -Dtck.mode=platform "-Dant.zip.url=${ANT_URL}" "-Dant.version=${ANT_VERSION}"
         popd
         
         pushd $TCK_ROOT/old-tck/source/release/JSF_BUILD/latest/

--- a/security/run-tck.sh
+++ b/security/run-tck.sh
@@ -177,10 +177,11 @@ OLD_TCK_HOME=security-tck
 if [[ -n $TCK_PORTING_KIT ]] 
 then
     echo "Hold on tight!"
-    
-    ANT_URL=https://dlcdn.apache.org//ant/binaries/apache-ant-1.9.16-bin.zip
-    ANT_ZIP=apache-ant-1.9.16-bin.zip
-    ANT_HOME=apache-ant-1.9.16
+
+    ANT_VERSION="1.9.16"
+    ANT_URL="https://dlcdn.apache.org//ant/binaries/apache-ant-${ANT_VERSION}bin.zip"
+    ANT_ZIP="apache-ant-${ANT_VERSION}-bin.zip"
+    ANT_HOME="apache-ant-${ANT_VERSION}"
     if ! test -d $ANT_HOME
     then
         echo "Installing Ant."
@@ -226,7 +227,7 @@ then
     then
         echo "Preparing Old TCK."
         pushd $TCK_ROOT/old-tck/build
-        mvn ${MVN_ARGS} install -Ddownload.plugin.skip=true
+        mvn ${MVN_ARGS} install "-Dant.zip.url=${ANT_URL}" "-Dant.version=${ANT_VERSION}"
         popd
         unzip ${UNZIP_ARGS} $TCK_ROOT/old-tck/source/release/SECURITYAPI_BUILD/latest/security-tck.zip
         pushd $JEETCK_MODS


### PR DESCRIPTION
This is the second attempt.

Setting `-Ddownload.plugin.skip=true` didn't help, because the plugin is reconfigured to use the `skipITs` property to control its skipping, instead of the default `download.plugin.skip`:

```
                    <execution>
                        <id>download-ant</id>
                        <phase>generate-sources</phase>
                        <goals>
                            <goal>wget</goal>
                        </goals>
                        <configuration>
                            <skip>${skipITs}</skip>
                            <url>${ant.zip.url}</url>
                            <unpack>true</unpack>
                            <outputDirectory>${project.build.directory}</outputDirectory>
                        </configuration>
                    </execution>
```

But setting `skipITs=true` would also have other effects, so I'm looking at another way to avoid download from the apache archive.

This however relies on the apacheant caching job archived artifacts to remain available, and requires to job to always archive the hardcoded 1.9.16 version. (It doesn't need to be this specific version, we just need to keep it in synch with what is hardcoded in the run-tck.sh scripts.)

WDYT @scottmarlow @jamezp ?